### PR TITLE
Fix typos, cleanup path and add extraction tests

### DIFF
--- a/src/level/common.py
+++ b/src/level/common.py
@@ -81,7 +81,7 @@ def extract_code(ai_response):
 
 def extract_callback(ai_response):
     """
-    提取 AI 响应中的代码块。
+    提取 AI 响应中的回调块。
     """
     import re
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -96,7 +96,7 @@
     "invalid_configuration_data": "Invalid configuration data",
     "config_updated_successfully": "Configuration updated successfully!",
     "starting_web_ui": "Starting WebUI on port: {port} || Docs port: {docs_port}",
-    "web_ui_titel": "NeoAI",
+    "web_ui_title": "NeoAI",
     "menu_chat": "💬Chat💬",
     "menu_config": "⚙️Settings⚙️",
     "menu_help": "📜Help📜",

--- a/src/locale/jp.json
+++ b/src/locale/jp.json
@@ -96,7 +96,7 @@
     "invalid_configuration_data": "無効な設定データです",
     "config_updated_successfully": "設定が正常に更新されました！",
     "starting_web_ui": "WebUIを起動します。ポート: {port} || Docsポート: {docs_port}",
-    "web_ui_titel": "NeoAI",
+    "web_ui_title": "NeoAI",
     "menu_chat": "💬チャット💬",
     "menu_config": "⚙️設定⚙️",
     "menu_help": "📜ヘルプ📜",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -96,7 +96,7 @@
     "invalid_configuration_data": "无效的配置数据",
     "config_updated_successfully": "配置更新成功！",
     "starting_web_ui": "正在启动 WebUI，端口: {port} || 文档端口: {docs_port}",
-    "web_ui_titel": "NeoAI",
+    "web_ui_title": "NeoAI",
     "menu_chat": "💬聊天💬",
     "menu_config": "⚙️设置⚙️",
     "menu_help": "📜帮助📜",

--- a/src/locale/zh-Miao.json
+++ b/src/locale/zh-Miao.json
@@ -96,7 +96,7 @@
     "invalid_configuration_data": "哎呀，配置好像不对喵！",
     "config_updated_successfully": "配置已成功更新，喵！",
     "starting_web_ui": "喵~ 正在启动 WebUI，端口是：{port} || 文档端口是：{docs_port}",
-    "web_ui_titel": "NekoAI",
+    "web_ui_title": "NekoAI",
     "menu_chat": "💬来聊天吧喵💬",
     "menu_config": "⚙️喵喵设置⚙️",
     "menu_help": "📜喵喵帮助~📜",

--- a/src/utils/scripts_handler.py
+++ b/src/utils/scripts_handler.py
@@ -135,11 +135,10 @@ def execute_in_subprocess(code, config, output_handler):
 
 def cleanup_temp_dir():
     """
-    清理脚本运行目录下的 temp_scripts 文件夹
+    清理主程序运行目录下的 temp_scripts 文件夹
     """
-    # 获取脚本运行目录
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    temp_dir = os.path.join(script_dir, "temp_scripts")
+    main_dir = get_main_directory()
+    temp_dir = os.path.join(main_dir, "temp_scripts")
 
     # 检查文件夹是否存在
     if os.path.exists(temp_dir):

--- a/src/web-ui/templates/index.html
+++ b/src/web-ui/templates/index.html
@@ -17,7 +17,7 @@
 
 <body>
     <script src="{{ url_for('static', filename='js/menu.js') }}"></script>
-    <div class="header" onclick="showMenu()">{{ "web_ui_titel" | translate }}</div>
+    <div class="header" onclick="showMenu()">{{ "web_ui_title" | translate }}</div>
     <div id="menuOverlay" class="hidden"></div>
     <div id="chat_container" class="chat-container">
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,23 @@
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from level.common import extract_code, extract_callback, extract_all_code, extract_all_callbacks
+
+class ExtractionTests(unittest.TestCase):
+    def test_extract_code_and_callback(self):
+        text = "before >>>RUN>>>print('hi')<<<RUN<<< middle >>>CALLBACK>>>done<<<CALLBACK<<< end"
+        self.assertEqual(extract_code(text), "print('hi')")
+        self.assertEqual(extract_callback(text), "done")
+
+    def test_extract_all(self):
+        text = (
+            ">>>RUN>>>a<<<RUN<<< text >>>RUN>>>b<<<RUN<<< >>>CALLBACK>>>cb1<<<CALLBACK<<< >>>CALLBACK>>>cb2<<<CALLBACK<<<"
+        )
+        self.assertEqual(extract_all_code(text), ["a", "b"])
+        self.assertEqual(extract_all_callbacks(text), ["cb1", "cb2"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix translation key typo `web_ui_title`
- clarify extract_callback docstring
- cleanup temp_scripts using main directory
- add tests for code/callback extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c9f777cc832688feeb4cfac8d27b